### PR TITLE
feat: improve reporting for open networks

### DIFF
--- a/Discreto.bat
+++ b/Discreto.bat
@@ -75,6 +75,9 @@ if ($profileLines) {
             try {
                 $profileDetailOutput = (netsh wlan show profile name="$profileName" key=clear 2>$null)
                 foreach ($dLine in $profileDetailOutput) {
+                    if ($dLine -match '(?:Autenticacion|Authentication)\s*:\s*(?:Abierta|Open)') {
+                        $password = "[Red Abierta / Sin Clave]"
+                    }
                     if ($dLine -match '(?:Contenido de la clave|Key Content|Key Material)\s*:\s*(.+)$') {
                         $password = $matches[1].Trim()
                         break

--- a/Normal.bat
+++ b/Normal.bat
@@ -69,6 +69,9 @@ if (-not $profileLines) {
             try {
                 $profileDetailOutput = (netsh wlan show profile name="$profileName" key=clear 2>$null)
                 foreach ($dLine in $profileDetailOutput) {
+                    if ($dLine -match '(?:Autenticacion|Authentication)\s*:\s*(?:Abierta|Open)') {
+                        $password = "[Red Abierta / Sin Clave]"
+                    }
                     if ($dLine -match '(?:Contenido de la clave|Key Content|Key Material)\s*:\s*(.+)$') {
                         $password = $matches[1].Trim()
                         break

--- a/core/engine.ps1
+++ b/core/engine.ps1
@@ -92,13 +92,14 @@ if (-not $profileLines) {
                 foreach ($dLine in $profileDetailOutput) {
                     if ($dLine -match ':\s*(.+)$') {
                         $val = $matches[1].Trim()
+                        # Detectar si la red es abierta
+                        if ($dLine -match '(?:Autenticacion|Authentication)\s*:\s*(?:Abierta|Open)') {
+                            $password = "[Red Abierta / Sin Clave]"
+                        }
                         # Si el valor no es el nombre del perfil y estamos en una linea indentada
-                        # netsh suele mostrar el "Key Content" al final de la seccion de seguridad
-                        if ($dLine -match '(?:Contenido de la clave|Key Content|Clave de seguridad|Key Material|Security key|Criptografia|Authentication|Autenticacion)') {
-                            if ($dLine -match '(?:Contenido de la clave|Key Content|Key Material)\s*:\s*(.+)$') {
-                                $password = $matches[1].Trim()
-                                break
-                            }
+                        if ($dLine -match '(?:Contenido de la clave|Key Content|Key Material)\s*:\s*(.+)$') {
+                            $password = $matches[1].Trim()
+                            break
                         }
                     }
                 }


### PR DESCRIPTION
This PR improves the accuracy of the WiFi scan results by explicitly identifying open networks (without security keys) instead of reporting them as 'Not found'.

Changes:
- Added logic to detect 'Authentication: Open' in netsh output.
- Updated embedded engines in Normal and Discrete batch files.
- Improved user feedback in the console.