### PR TITLE
docs: fix linting and formatting issues in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ Para ver los logs ocultos:
 Este software ha sido creado exclusivamente para fines **educativos y de auditoría personal**. El autor no se responsabiliza por el uso indebido o ilegal de esta herramienta. **Usala siempre bajo tu propia responsabilidad y en entornos autorizados.**
 
 ---
-<p align="center">
-  Developed with ❤️ by <a href="https://github.com/ANONIMO432HZ">4N0N1M0</a>
-</p>
+
+Developed with ❤️ by [4N0N1M0](https://github.com/ANONIMO432HZ)
+

--- a/README_EN.md
+++ b/README_EN.md
@@ -38,8 +38,10 @@
 All results are automatically organized. Files generated in **Stealth** and **Ghost** modes are saved in the **`logs/`** folder, which is automatically marked as **hidden** by the system.
 
 To view hidden logs:
+
 1. Open File Explorer.
 2. Go to **View** > **Show** > **Hidden items**.
+
 
 ---
 
@@ -59,6 +61,6 @@ To view hidden logs:
 This software has been created exclusively for **educational and personal auditing purposes**. The author is not responsible for the misuse or illegal use of this tool. **Always use it at your own risk and in authorized environments.**
 
 ---
-<p align="center">
-  Developed with ❤️ by <a href="https://github.com/ANONIMO432HZ">4N0N1M0</a>
-</p>
+
+Developed with ❤️ by [4N0N1M0](https://github.com/ANONIMO432HZ)
+


### PR DESCRIPTION
- Add missing blank line before list in README_EN.md (MD032).
- Replace inline HTML with standard Markdown in footers (MD033).

Co-authored-by: dr-tony777 <219462552+dr-tony777@users.noreply.github.com>
